### PR TITLE
Linux compatibility issue in Picoprobe

### DIFF
--- a/pyocd/probe/picoprobe.py
+++ b/pyocd/probe/picoprobe.py
@@ -72,7 +72,12 @@ class PicoLink(object):
     # ------------------------------------------- #
     def open(self):
         # Only one configuration considered
-        self._dev.set_configuration()
+        try:
+            # Will throw if no configuration is active (returning None is for wimps)
+            self._dev.get_active_configuration()
+        except core.USBError:
+            # Will throw on Linux if a configuration is already active.
+            self._dev.set_configuration()
         # Search the Vendor Specific interface in first configuration
         for i in self._dev[0]:
             if i.bInterfaceClass == PicoLink.CLASS:


### PR DESCRIPTION
I found a problem while testing on Linux (Mint 20.1):

Trying to select a configuration for an USB device that already has one
will raise an USBerror exception with "Resource Busy" on Linux.

Given that the Picoprobe also contains a CDC interface, it's almost certain that that will be the case.
The active configuration is now checked, and selected if none is there.
No check is done on the interface, as only another debug server would claim it.